### PR TITLE
(v0.6.2) Changed objectMakr to quadrantFactory

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "quadskeepr",
   "description": "Adjustable quadrant-based collision detection.",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "author": {
     "name": "Josh Goldberg",
     "email": "joshuakgoldberg@outlook.com"
@@ -14,9 +14,6 @@
     "url": "https://github.com/FullScreenShenanigans/QuadsKeepr/issues"
   },
   "license": "MIT",
-  "dependencies": {
-    "objectmakr": "0.6.X"
-  },
   "devDependencies": {
     "gulp-shenanigans": "0.6.X"
   }

--- a/shenanigans.json
+++ b/shenanigans.json
@@ -1,10 +1,7 @@
 {
-  "dependencies": {
-    "ObjectMakr": "0.6.X"
-  },
   "package": {
     "description": "Adjustable quadrant-based collision detection.",
     "name": "QuadsKeepr",
-    "version": "0.6.1"
+    "version": "0.6.2"
   }
 }

--- a/src/IQuadsKeepr.ts
+++ b/src/IQuadsKeepr.ts
@@ -1,4 +1,12 @@
-import { IObjectMakr } from "objectmakr/lib/IObjectMakr";
+/**
+ * Creates new Quadrants.
+ * 
+ * @type TThing   Type of Things in the Quadrant.
+ * @returns A new Quadrant.
+ */
+export interface IQuadrantFactory<TThing extends IThing> {
+    (): IQuadrant<TThing>;
+}
 
 /**
  * Any rectangular bounding box.
@@ -157,12 +165,14 @@ export interface IQuadrantChangeCallback {
 
 /**
  * Settings to initialize a new IQuadsKeepr.
+ * 
+ * @type TThing   Type of Things in the Quadrants.
  */
-export interface IQuadsKeeprSettings {
+export interface IQuadsKeeprSettings<TThing extends IThing> {
     /**
-     * An ObjectMakr used to create Quadrants.
+     * Creates new Quadrants.
      */
-    objectMaker?: IObjectMakr;
+    quadrantFactory?: IQuadrantFactory<TThing>;
 
     /**
      * How many QuadrantRows to keep at a time.

--- a/src/QuadsKeepr.ts
+++ b/src/QuadsKeepr.ts
@@ -1,7 +1,6 @@
-import { IObjectMakr } from "objectmakr/lib/IObjectMakr";
-
 import {
-     IQuadrant, IQuadrantChangeCallback, IQuadrantCol, IQuadrantRow, IQuadsKeepr, IQuadsKeeprSettings, IThing
+    IQuadrant, IQuadrantChangeCallback, IQuadrantCol, IQuadrantFactory,
+    IQuadrantRow, IQuadsKeepr, IQuadsKeeprSettings, IThing
 } from "./IQuadsKeepr";
 
 /**
@@ -31,9 +30,9 @@ export class QuadsKeepr<TThing extends IThing> implements IQuadsKeepr<TThing> {
     public left: number;
 
     /**
-     * The ObjectMakr factory used to create Quadrant objects.
+     * Creates new Quadrants.
      */
-    private objectMaker: IObjectMakr;
+    private readonly quadrantFactory: IQuadrantFactory<TThing>;
 
     /**
      * How many rows of Quadrants there should be initially.
@@ -115,15 +114,15 @@ export class QuadsKeepr<TThing extends IThing> implements IQuadsKeepr<TThing> {
      * 
      * @param settings   Settings to be used for initialization.
      */
-    constructor(settings: IQuadsKeeprSettings) {
+    constructor(settings: IQuadsKeeprSettings<TThing>) {
         if (!settings) {
             throw new Error("No settings object given to QuadsKeepr.");
         }
-        if (!settings.objectMaker) {
-            throw new Error("No ObjectMaker given to QuadsKeepr.");
+        if (!settings.quadrantFactory) {
+            throw new Error("No quadrantFactory given to QuadsKeepr.");
         }
 
-        this.objectMaker = settings.objectMaker;
+        this.quadrantFactory = settings.quadrantFactory;
         this.numRows = (settings.numRows | 0) || 2;
         this.numCols = (settings.numCols | 0) || 2;
         this.quadrantWidth = (settings.quadrantWidth | 0) || 2;
@@ -601,7 +600,7 @@ export class QuadsKeepr<TThing extends IThing> implements IQuadsKeepr<TThing> {
      * @returns The newly created Quadrant.
      */
     private createQuadrant(left: number, top: number): IQuadrant<TThing> {
-        const quadrant: IQuadrant<TThing> = this.objectMaker.make("Quadrant");
+        const quadrant: IQuadrant<TThing> = this.quadrantFactory();
 
         quadrant.changed = true;
         quadrant.things = {};

--- a/test/tsconfig.json
+++ b/test/tsconfig.json
@@ -2,6 +2,7 @@
     "compilerOptions": {
         "declaration": true,
         "module": "amd",
+        "moduleResolution": "node",
         "noImplicitAny": true,
         "noImplicitReturns": true,
         "noImplicitThis": true,
@@ -11,7 +12,7 @@
         "outDir": "..",
         "rootDir": "..",
         "strictNullChecks": true,
-        "target": "es3"
+        "target": "es5"
     },
     "include": [
         "./**/*.ts"

--- a/test/utils/fakes.ts
+++ b/test/utils/fakes.ts
@@ -1,9 +1,9 @@
-import { QuadsKeepr } from "../../src/QuadsKeepr";
 import { IQuadsKeepr, IQuadsKeeprSettings, IThing } from "../../src/IQuadsKeepr";
+import { QuadsKeepr } from "../../src/QuadsKeepr";
 
 /**
  * 
  */
-export function stubQuadsKeepr(settings: IQuadsKeeprSettings): IQuadsKeepr<IThing> {
+export function stubQuadsKeepr(settings: IQuadsKeeprSettings<IThing>): IQuadsKeepr<IThing> {
     return new QuadsKeepr(settings);
 }


### PR DESCRIPTION
Removed the ObjectMakr dependency because it was unnecessary.